### PR TITLE
Append the platform when tagging a version

### DIFF
--- a/Specs/TelevisionAcademyIOSPlayerPlugin/0.2.19/TelevisionAcademyIOSPlayerPlugin.podspec
+++ b/Specs/TelevisionAcademyIOSPlayerPlugin/0.2.19/TelevisionAcademyIOSPlayerPlugin.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.homepage         = "https://github.com/applicaster-plugins/TelevisionAcademyPlayerPlugin"
     s.license          = 'MIT'
     s.author           = { "Anatolii Afanasiev" => "anatolii.afanasiev@corewillsoft.com" }
-    s.source           = { :git => "https://github.com/applicaster-plugins/TelevisionAcademyPlayerPlugin.git", :tag => s.version.to_s }
+    s.source           = { :git => "https://github.com/applicaster-plugins/TelevisionAcademyPlayerPlugin.git", :tag => 'ios-' + s.version.to_s }
     s.platform = :ios
     s.ios.deployment_target = "10.0"
     s.requires_arc = true

--- a/Specs/TelevisionAcademyIOSPlayerPlugin/0.5.0/TelevisionAcademyIOSPlayerPlugin.podspec
+++ b/Specs/TelevisionAcademyIOSPlayerPlugin/0.5.0/TelevisionAcademyIOSPlayerPlugin.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
     s.static_framework = true
     s.resources = ['ios/TelevisionAcademyIOSPlayerPlugin/SupportingFiles/*']
     s.source_files = 'ios/TelevisionAcademyIOSPlayerPlugin/PluginClasses/*.swift','ios/TelevisionAcademyIOSPlayerPlugin/PluginClasses/**/*.swift'
+    s.dependency 'ZappPlugins'
     s.dependency 'BitmovinPlayer','~> 2.42.0'
     s.dependency 'google-cast-sdk-no-bluetooth', '= 4.4.4'
     s.dependency 'BitmovinAnalyticsCollector/BitmovinPlayer','~> 1.12.0'

--- a/tvos/plugin/ios/BitmovinPlayer.podspec
+++ b/tvos/plugin/ios/BitmovinPlayer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "BitmovinRNPlayer"
-	s.version = "0.4.29"
+	s.version = "0.5.1"
 	s.platform = :tvos, :ios
 	s.swift_versions = ['5.1']
 	s.summary = "ZappPlugins"
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 	s.author = "Applicaster LTD."
 	s.source = {
 		 :git => 'git@github.com:applicaster-plugins/TelevisionAcademyPlayerPlugin.git',
-		 :tag => s.version.to_s
+		 :tag => 'tvos-' + s.version.to_s
   }
 	s.dependency 'React'
 	s.dependency 'ZappCore'


### PR DESCRIPTION
We have a repository with 3 different platforms but we are not doing any distinction in the tags, this is leading to problems. This fix pretend to solve that appending the platform to the tags.