### PR TITLE
Fix one of the query parameter's name for the DSP service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 project.ext {
-    releaseVersion = '0.7.0'
+    releaseVersion = '0.7.1'
     releaseVersionCode = 1
     minSdkVersion = 17
     targetSdkVersion = 29

--- a/android/src/main/java/com/applicaster/plugin/televisionacademyplayer/network/OKHttpRepsotory.kt
+++ b/android/src/main/java/com/applicaster/plugin/televisionacademyplayer/network/OKHttpRepsotory.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 class OKHttpRepsotory {
     fun contentUIDS( competition_id: String,submission_id: String, token: String, callback: (ResponseStatusCodes, APAtomFeed?) -> Unit) {
          val urlBuilder = HttpUrl.parse(ConfigurationRepository.dspBaseUrl)!!.newBuilder()
-                   urlBuilder.addQueryParameter("competition_id", competition_id)
+                   urlBuilder.addQueryParameter("competitionId", competition_id)
         urlBuilder.addQueryParameter("uid", submission_id)
         urlBuilder.addQueryParameter("token", token)
         val url = urlBuilder.build().toString() + dsp_parameters_url


### PR DESCRIPTION
Fix for [IM-797](https://applicaster.atlassian.net/secure/RapidBoard.jspa?rapidView=232&projectKey=IM&modal=detail&selectedIssue=IM-797&quickFilter=552): content_group is not being passed as a parameter in the continue watching

Basically, compared query parameters with the iOS code, once changed - I get the content_group extension as expected