### PR TITLE
TVA-QB: Update key and namespace when looking for the user_id in the local storage

### DIFF
--- a/tvos/manifests/android_tv.json
+++ b/tvos/manifests/android_tv.json
@@ -13,8 +13,8 @@
     }
   ],
   "dependency_name": "@applicaster/quick-brick-television-academy-bitmovin-player",
-  "dependency_version": "0.8.0",
-  "manifest_version": "0.8.0",
+  "dependency_version": "0.8.2",
+  "manifest_version": "0.8.2",
   "platform": "android",
   "author_name": "Sergey Zhigunov",
   "author_email": "s.zhyhunov@applicaster.com",
@@ -34,7 +34,7 @@
   "react_bundle_url": "",
   "extra_dependencies": [],
   "npm_dependencies": [
-    "@applicaster/quick-brick-television-academy-bitmovin-player@0.7.0"
+    "@applicaster/quick-brick-television-academy-bitmovin-player@0.8.2"
   ],
   "project_dependencies": [
     {

--- a/tvos/package.json
+++ b/tvos/package.json
@@ -5,7 +5,7 @@
     "plugin",
     "development-app"
   ],
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "",
   "main": "./src/index.js",
   "scripts": {

--- a/tvos/plugin/android/gradle.properties
+++ b/tvos/plugin/android/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.8.0
+VERSION_NAME=0.8.1
 VERSION_CODE=1
 GROUP=com.tva.quickbrickplayerplugin
 ARTIFACT_ID=TelevisionAcademyQuickBrickPlayer

--- a/tvos/plugin/android/gradle.properties
+++ b/tvos/plugin/android/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.8.1
+VERSION_NAME=0.8.2
 VERSION_CODE=1
 GROUP=com.tva.quickbrickplayerplugin
 ARTIFACT_ID=TelevisionAcademyQuickBrickPlayer

--- a/tvos/plugin/android/src/main/kotlin/com/tva/quickbrickplayerplugin/TVAQuickBrickPlayerView.kt
+++ b/tvos/plugin/android/src/main/kotlin/com/tva/quickbrickplayerplugin/TVAQuickBrickPlayerView.kt
@@ -59,7 +59,8 @@ class TVAQuickBrickPlayerView(context: Context, attrs: AttributeSet?) : FrameLay
     private val TRACK_TIME_INTERVAL = TimeUnit.SECONDS.toMillis(5)
     private var bitmovinPlayer: BitmovinPlayer? = null
     private var bitmovinAnalyticInteractor: BitmovinAnalyticInteractor
-    private val TOKEN_NAMESPACE = "login"
+    private val LOGIN_NAMESPACE = "login"
+    private val USERID_KEY = "user_id"
     private val TOKEN_KEY = "token"
     private var audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
@@ -254,7 +255,7 @@ class TVAQuickBrickPlayerView(context: Context, attrs: AttributeSet?) : FrameLay
                 }
             }
         }
-        bitmovinAnalyticInteractor.initializeAnalyticsCollector(context, sourceId, heartbeatInterval, customUserId())
+        bitmovinAnalyticInteractor.initializeAnalyticsCollector(context, sourceId, heartbeatInterval, getCustomUserId())
     }
 
     fun setPluginConfiguration(params: ReadableMap) {
@@ -404,17 +405,16 @@ class TVAQuickBrickPlayerView(context: Context, attrs: AttributeSet?) : FrameLay
     }
 
     private fun getToken(): String {
-        var token = LocalStorage.storageRepository?.get(TOKEN_KEY, TOKEN_NAMESPACE) ?: ""
+        var token = LocalStorage.storageRepository?.get(TOKEN_KEY, LOGIN_NAMESPACE) ?: ""
         return token.replace("\"", "")
 
     }
 
     private fun getCustomUserId(): String? {
-        var id = LocalStorage.storageRepository?.get(CUSTOM_USER_ID_KEY, CUSTOM_USER_ID_NAMESPACE) ?: ""
+        var id = LocalStorage.storageRepository?.get(USERID_KEY, LOGIN_NAMESPACE) ?: ""
         return id.replace("\"", "")
 
     }
-
 
     override fun onHostResume() {
         bitmovinPlayer?.onResume()

--- a/tvos/plugin/package.json
+++ b/tvos/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-television-academy-bitmovin-player",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "",
   "main": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
[IM-498](https://applicaster.atlassian.net/secure/RapidBoard.jspa?rapidView=232&projectKey=IM&modal=detail&selectedIssue=IM-498&quickFilter=552): QB TVs - Specify the user id in Bitmovin Analytics (inside the player plugin) + fix build errors